### PR TITLE
API calls for Clan command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ ENV/
 .mypy_cache/
 
 credentials.json
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -306,6 +306,35 @@ Gets public information about currently available Milestones.
 
 ---
 
+> get_group_for_member()
+
+This function is a coroutine.
+
+Gets information about the clan of a member.
+
+**Response**: See [GroupV2.GetGroupsForMember](https://bungie-net.github.io/multi/operation_get_GroupV2-GetGroupsForMember.html#operation_get_GroupV2-GetGroupsForMember)
+
+---
+
+> get_weekly_milestones()
+
+This function is a coroutine.
+
+Gets information about milestones for a clan
+
+**Response**: See [Destiny2.GetClanWeeklyRewardState](https://bungie-net.github.io/multi/operation_get_Destiny2-GetClanWeeklyRewardState.html#operation_get_Destiny2-GetClanWeeklyRewardState)
+
+---
+
+> get_weekly_milestone_definition()
+
+This function is a coroutine.
+
+This function retreives additional information for a milestone from the destiny2 Manifest.
+
+**Response**: See [Destiny.Definitions.Milestones.DestinyMilestoneDefinition](https://bungie-net.github.io/multi/schema_Destiny-Definitions-Milestones-DestinyMilestoneDefinition.html#schema_Destiny-Definitions-Milestones-DestinyMilestoneDefinition)
+---
+
 For additional information on how the API endpoints function, refer to the [official documentation](https://bungie-net.github.io/multi/index.html).
 
 ## Running Tests

--- a/pydest/api.py
+++ b/pydest/api.py
@@ -257,6 +257,10 @@ class API:
         """Gets custom localized content for the milestone of
         the given hash, if it exists.
 
+        Args:
+            milestone_hash (int):
+                A valid hash id of a Destiny 2 milestone
+
         Returns:
             json (dict)
         """
@@ -266,7 +270,7 @@ class API:
 
 
     async def get_public_milestones(self):
-        """Gets public information about currently available Milestones
+        """Gets information about the current public Milestones
 
         Returns:
             json (dict)
@@ -293,11 +297,11 @@ class API:
 
 
     async def get_weekly_milestones(self, group_id):
-        """Gets the weekly milestones for a given groupId
+        """Gets the weekly milestones for a clan
 
         Args:
             groupId (int):
-                The groupId for the clan that is being requested.
+                The groupId of clan.
 
         returns json(dict) 
         """

--- a/pydest/api.py
+++ b/pydest/api.py
@@ -311,8 +311,8 @@ class API:
         return await self._get_request(url)
 
 
-    async def get_weekly_milestone_definitions(self, milestone_hash):
-        """Gets the weekly milestones definition for a given milestoneHash
+    async def get_milestone_definitions(self, milestone_hash):
+        """Gets the milestones definition for a given milestoneHash
         
         Args:
             milestone_hash (int):

--- a/pydest/api.py
+++ b/pydest/api.py
@@ -9,6 +9,7 @@ import pydest
 
 DESTINY2_URL = 'https://www.bungie.net/Platform/Destiny2/'
 USER_URL = 'https://www.bungie.net/Platform/User/'
+GROUP_URL = 'https://www.bungie.net/Platform/GroupV2/'
 
 class API:
     """This module contains async requests for the Destiny 2 API.
@@ -271,4 +272,36 @@ class API:
             json (dict)
         """
         url = DESTINY2_URL + 'Milestones/'
+        return await self._get_request(url)
+
+    async def get_groups_for_member(self, membership_type, membership_id):
+        """Gets information about the groups an individual member has joined
+
+        Returns:
+            json(dict)
+        """
+        # /{filter}/{groupType}/ | 0(NO FILTER)/1(CLANS)
+        url = GROUP_URL + 'User/{}/{}/0/1/'
+        url = url.format(membership_type, membership_id)
+        return await self._get_request(url)
+
+
+    async def get_weekly_milestones(self, group_id):
+        """Gets the weekly milestones for a given groupId
+
+        returns json object
+        """
+        # /Clan/{groupId}/WeeklyRewardState/
+        url = DESTINY2_URL + 'Clan/{}/WeeklyRewardState/'.format(group_id)
+        # using the returned json
+        return await self._get_request(url)
+
+
+    async def get_weekly_milestone_definitions(self, milestoneHash):
+        """Gets the weekly milestones definition for a given milestoneHash
+
+        returns json object
+        """
+        # /Manifest/DestinyMilestoneDefinition/{milestoneHash}
+        url = DESTINY2_URL + 'Manifest/DestinyMilestoneDefinition/{}'.format(milestoneHash)
         return await self._get_request(url)

--- a/pydest/api.py
+++ b/pydest/api.py
@@ -276,11 +276,17 @@ class API:
 
     async def get_groups_for_member(self, membership_type, membership_id):
         """Gets information about the groups an individual member has joined
-
+        
+        Args:
+            membership_type (int):
+                A valid non-BungieNet membership type (BungieMembershipType)
+            membership_id (int):
+                Destiny membership ID
+        
         Returns:
             json(dict)
         """
-        # /{filter}/{groupType}/ | 0(NO FILTER)/1(CLANS)
+        # /{membershipType}/{membershipId}/ | 0(NO FILTER)/1(CLANS)
         url = GROUP_URL + 'User/{}/{}/0/1/'
         url = url.format(membership_type, membership_id)
         return await self._get_request(url)
@@ -289,7 +295,11 @@ class API:
     async def get_weekly_milestones(self, group_id):
         """Gets the weekly milestones for a given groupId
 
-        returns json object
+        Args:
+            groupId (int):
+                The groupId for the clan that is being requested.
+
+        returns json(dict) 
         """
         # /Clan/{groupId}/WeeklyRewardState/
         url = DESTINY2_URL + 'Clan/{}/WeeklyRewardState/'.format(group_id)
@@ -297,11 +307,15 @@ class API:
         return await self._get_request(url)
 
 
-    async def get_weekly_milestone_definitions(self, milestoneHash):
+    async def get_weekly_milestone_definitions(self, milestone_hash):
         """Gets the weekly milestones definition for a given milestoneHash
-
-        returns json object
+        
+        Args:
+            milestone_hash (int):
+                The hash value that represents the milestone within the manifest
+                
+        returns json(dict)
         """
         # /Manifest/DestinyMilestoneDefinition/{milestoneHash}
-        url = DESTINY2_URL + 'Manifest/DestinyMilestoneDefinition/{}'.format(milestoneHash)
+        url = DESTINY2_URL + 'Manifest/DestinyMilestoneDefinition/{}'.format(milestone_hash)
         return await self._get_request(url)

--- a/pydest/test/test_integration.py
+++ b/pydest/test/test_integration.py
@@ -9,7 +9,25 @@ with open('credentials.json') as f:
     api_key = json.load(f)['api-key']
 
 
-class TestGetBungieNetUserById(object):
+class BaseTestClass(object):
+
+    _membership_id = 4611686018467257491
+    _membership_type = 4
+
+    @pytest.mark.asyncio
+    async def test_is_dict(self, res):
+        assert type(res) is dict
+
+    @pytest.mark.asyncio
+    async def test_error_code(self, res):
+        assert res['ErrorCode'] != 7
+    
+    @pytest.mark.asyncio
+    async def test_error_code_true(self, res):
+        assert res['ErrorCode'] == 1
+
+
+class TestGetBungieNetUserById(BaseTestClass):
 
     @pytest.fixture
     @pytest.mark.asyncio
@@ -19,16 +37,8 @@ class TestGetBungieNetUserById(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetMembershipDataById(object):
+class TestGetMembershipDataById(BaseTestClass):
 
     @pytest.fixture
     @pytest.mark.asyncio
@@ -38,16 +48,8 @@ class TestGetMembershipDataById(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetDestinyManifest(object):
+class TestGetDestinyManifest(BaseTestClass):
 
     @pytest.fixture
     @pytest.mark.asyncio
@@ -57,16 +59,8 @@ class TestGetDestinyManifest(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestSearchDestinyPlayer(object):
+class TestSearchDestinyPlayer(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
@@ -76,93 +70,61 @@ class TestSearchDestinyPlayer(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
-        pass
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetProfile(object):
+class TestGetProfile(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
     async def res(self):
         destiny = pydest.Pydest(api_key)
-        r = await destiny.api.get_profile(1, '123', ['Characters'])
+        r = await destiny.api.get_profile(self._membership_type, self._membership_id, ['Characters'])
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetCharacter(object):
+class TestGetCharacter(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
     async def res(self):
         destiny = pydest.Pydest(api_key)
-        r = await destiny.api.get_character(1, '123', '123', ['CharacterActivities'])
+        profile = await destiny.api.get_profile(self._membership_type, self._membership_id, ["Characters"])
+        res = profile['Response']['characters']['data']
+        character_hash = ""
+        for item in res:
+            character_hash = item
+            break
+
+        r = await destiny.api.get_character(self._membership_type, self._membership_id, character_hash, ['CharacterActivities'])
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetClanWeeklyRewardState(object):
+class TestGetClanWeeklyRewardState(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
     async def res(self):
         destiny = pydest.Pydest(api_key)
-        r = await destiny.api.get_clan_weekly_reward_state('123')
+        res = await destiny.api.get_groups_for_member(self._membership_type, self._membership_id)
+        group_id = res['Response']['results'][0]['member']['groupId']
+        r = await destiny.api.get_clan_weekly_reward_state(group_id)
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetItem(object):
+class TestGetItem(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
     async def res(self):
         destiny = pydest.Pydest(api_key)
-        r = await destiny.api.get_item(1, '123', '123', ['ItemCommonData'])
+        r = await destiny.api.get_item(self._membership_type, self._membership_id, '1048266744', ['ItemCommonData'])
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetPostGameCarnageReport(object):
+class TestGetPostGameCarnageReport(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
@@ -172,16 +134,8 @@ class TestGetPostGameCarnageReport(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetHistoricalStatsDefinition(object):
+class TestGetHistoricalStatsDefinition(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
@@ -191,16 +145,8 @@ class TestGetHistoricalStatsDefinition(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetPublicMilestoneContent(object):
+class TestGetPublicMilestoneContent(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
@@ -210,16 +156,8 @@ class TestGetPublicMilestoneContent(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
 
-    @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
-
-
-class TestGetPublicMilestones(object):
+class TestGetPublicMilestones(BaseTestClass):
 
     @pytest.mark.asyncio
     @pytest.fixture
@@ -229,10 +167,32 @@ class TestGetPublicMilestones(object):
         destiny.close()
         return r
 
-    @pytest.mark.asyncio
-    async def test_is_dict(self, res):
-        assert type(res) is dict
+
+class TestGetGroupForMember(BaseTestClass):
 
     @pytest.mark.asyncio
-    async def test_error_code(self, res):
-        assert res['ErrorCode'] != 7
+    @pytest.fixture
+    async def res(self):
+        destiny = pydest.Pydest(api_key)
+        r = await destiny.api.get_groups_for_member(1, 4611686018467257491)
+        destiny.close()
+        return r
+
+
+class TestGetMilestoneDefinitions(BaseTestClass):
+
+    @pytest.mark.asyncio
+    @pytest.fixture
+    async def res(self):
+        destiny = pydest.Pydest(api_key)
+        milestone_r = await destiny.api.get_public_milestones()
+        ms = milestone_r['Response']
+        milestone_hash = ""
+        for item in ms:
+            milestone_hash = item
+            break
+            
+        r = await destiny.api.get_milestone_definitions(milestone_hash)
+        destiny.close()
+        return r
+        


### PR DESCRIPTION
Adding new callers for the Destiny2 API

## Context
The new clan command that is being added to Spirit requires access to additional Destiny2 API endpoints and manifest information.    

## How Has This Been Tested?
I have tested it locally with success but further testing needed.

## Screenshots :
Successful output 
![image](https://user-images.githubusercontent.com/16713447/34625251-ff65a33c-f225-11e7-9304-e003599e9abb.png)

## Types of changes
New entry points into the Destiny2 API 

## Checklist:
- [X] My code follows the code style of this project.  