### PR TITLE
Added Korean and Simplified Chinese to languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Aside from the very first time this function is called (when the manifest is dow
 **Parameters**
 - `hash_id` - The unique identifier for this entity. Guaranteed to be unique for the type of entity, but not globally. When entities refer to each other in Destiny content, it is this hash that they are referring to.
 - `definition` - The type of entity to be decoded. In the [official documentation](https://bungie-net.github.io/multi/index.html), these entities are proceeded by a blue 'Manifest' tag (eg. *DestinyClassDefinition*).
-- `language` [optional] - The desired language of the response, given as a string. The following languages are supported (and should be given as shown): en, fr, es, de, it, ja, pt-br, es-mx, ru, pl, zn-cht. If no language is given, English will be used.
+- `language` [optional] - The desired language of the response, given as a string. The following languages are supported (and should be given as shown): en, fr, es, de, it, ja, pt-br, es-mx, ru, pl, zn-cht, ko, zh-chs. If no language is given, English will be used.
 
 **Returns**: Python dictionary containing static information that the given hash and definition represent in JSON.
 
@@ -96,7 +96,7 @@ This function is a coroutine.
 Updates the manifest corresponding to the language given. If no language is given, the default is English. This function is designed to be used for a program that is running for extended periods of time where the manifest may need to be updated. Usually the manifest is only updated the first time that `decode_hash()` is called. But as the manifest will likely change over time, this function will help keep the manifest current.
 
 **Parameters**
-- `language` [optional] - The desired language of the response, given as a string. The following languages are supported (and should be given as shown): en, fr, es, de, it, ja, pt-br, es-mx, ru, pl, zn-cht. If no language is given, English will be used.
+- `language` [optional] - The desired language of the response, given as a string. The following languages are supported (and should be given as shown): en, fr, es, de, it, ja, pt-br, es-mx, ru, pl, zn-cht, ko, zh-cht. If no language is given, English will be used.
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This function is a coroutine.
 Updates the manifest corresponding to the language given. If no language is given, the default is English. This function is designed to be used for a program that is running for extended periods of time where the manifest may need to be updated. Usually the manifest is only updated the first time that `decode_hash()` is called. But as the manifest will likely change over time, this function will help keep the manifest current.
 
 **Parameters**
-- `language` [optional] - The desired language of the response, given as a string. The following languages are supported (and should be given as shown): en, fr, es, de, it, ja, pt-br, es-mx, ru, pl, zn-cht, ko, zh-cht. If no language is given, English will be used.
+- `language` [optional] - The desired language of the response, given as a string. The following languages are supported (and should be given as shown): en, fr, es, de, it, ja, pt-br, es-mx, ru, pl, zn-cht, ko, zh-chz. If no language is given, English will be used.
 
 ### API
 

--- a/pydest/manifest.py
+++ b/pydest/manifest.py
@@ -16,7 +16,7 @@ class Manifest:
     def __init__(self, api):
         self.api = api
         self.manifest_files = {'en': '', 'fr': '', 'es': '', 'de': '', 'it': '', 'ja': '', 'pt-br': '', 'es-mx': '',
-                               'ru': '', 'pl': '', 'zh-cht': ''}
+                               'ru': '', 'pl': '', 'zh-cht': '', 'ko': '', 'zh-chs': ''}
 
     async def decode_hash(self, hash_id, definition, language):
         """Get the corresponding static info for an item given it's hash value


### PR DESCRIPTION
Korean and Simplified Chinese are missing from current version of the wrapper, but supported by the Bungie's API.